### PR TITLE
Prevent browser mixed content warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-  <a href="http://github.com/jackalope/jackalope"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+  <a href="https://github.com/jackalope/jackalope"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
   <div class="#header">
   </div>
 
@@ -20,7 +20,7 @@
     <div class="description">
 
         <p>
-            Jackalope is an open source implementation of the <a href="http://phpcr.github.com/" class="external-link">PHPCR API</a>, which is a PHP adaption of the Java Content Repository (<a href="http://en.wikipedia.org/wiki/Content_repository_API_for_Java" class="external-link">JCR</a>) standard, an open API specification defined in <a href="http://jcp.org/en/jsr/detail?id=170" title="JSR: Java Specification Request" class="external-link">JSR-170</a>/<a href="http://jcp.org/en/jsr/detail?id=283" title="JSR: Java Specification Request" class="external-link">283</a>.<br/>
+            Jackalope is an open source implementation of the <a href="https://phpcr.github.com/" class="external-link">PHPCR API</a>, which is a PHP adaption of the Java Content Repository (<a href="https://en.wikipedia.org/wiki/Content_repository_API_for_Java" class="external-link">JCR</a>) standard, an open API specification defined in <a href="https://jcp.org/en/jsr/detail?id=170" title="JSR: Java Specification Request" class="external-link">JSR-170</a>/<a href="https://jcp.org/en/jsr/detail?id=283" title="JSR: Java Specification Request" class="external-link">283</a>.<br/>
             Jackalope implements the PHPCR interfaces and storage agnostic application code.
             You need to chose one of the <em>transport</em> implementations to get a functional
             application.
@@ -28,7 +28,7 @@
         <p>
             <a href="https://github.com/jackalope/jackalope-jackrabbit">Jackalope-Jackrabbit</a>
             is the most feature complete and reliable implementation, storing content into the Java server
-            <a href="http://jackrabbit.apache.org/" class="external-link">Apache Jackrabbit</a>, the JCR
+            <a href="https://jackrabbit.apache.org/" class="external-link">Apache Jackrabbit</a>, the JCR
             reference implementation. <br/>
             <a href="https://github.com/jackalope/jackalope-doctrine-dbal">Jackalope-Doctrine-Dbal</a>
             uses the Doctrine database abstraction layer to store data into postgres, mysql or sqlite
@@ -44,7 +44,7 @@
 
         <ul class="links">
             <li><a href="https://github.com/jackalope/jackalope/wiki/">About</a></li>
-            <li><a href="http://phpcr.github.com/">PHPCR API</a></li>
+            <li><a href="https://phpcr.github.com/">PHPCR API</a></li>
             <li><a href="https://github.com/jackalope/jackalope/wiki/Collaboration">Collaboration</a></li>
             <li><a href="https://groups.google.com/forum/#!forum/jackalope-dev">Mailinglist</a></li>
         </ul>


### PR DESCRIPTION
Load and external content over HTTPS to prevent browser mixed content warnings. Also link to external content over HTTPS.
